### PR TITLE
truncate only defined models. Support more than mysql as a side effect.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,8 +50,11 @@ module.exports = function (options) {
   function truncateModels() {
     return Sequelize.Promise.each(
       Object.keys(options.models), function (modelName) {
-        return options.models[modelName].truncate({cascade: true});
-    });
+        if (options.models[modelName] instanceof sequelize.Model) {
+          return options.models[modelName].truncate({cascade: true});
+        }
+      }
+    );
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,10 @@ module.exports = function (options) {
     return Sequelize.Promise.each(
       Object.keys(options.models), function (modelName) {
         if (options.models[modelName] instanceof sequelize.Model) {
-          return options.models[modelName].truncate({cascade: true});
+          return options.models[modelName].truncate({
+            cascade: true,
+            force: true
+          });
         }
       }
     );

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ module.exports = function (options) {
 
   // Set up test database and load fixtures
   return runMigrations().then(function () {
-    return truncateTables();
+    return truncateModels();
   }).then(function () {
     return loadFixtures();
   });
@@ -44,19 +44,13 @@ module.exports = function (options) {
   }
 
   /**
-   * Truncates all tables in the test database.
+   * Truncates all models
    * @returns {Promise}
    */
-  function truncateTables() {
-    return sequelize.query('SET FOREIGN_KEY_CHECKS=0').then(function () {
-      return queryInterface.showAllTables();
-    }).each(function (tableName) {
-      // don't truncate the migrations table
-      if (tableName.toLowerCase() != 'sequelizemeta') {
-        return sequelize.query('TRUNCATE ' + tableName);
-      }
-    }).then(function () {
-      return sequelize.query('SET FOREIGN_KEY_CHECKS=1');
+  function truncateModels() {
+    return Sequelize.Promise.each(
+      Object.keys(options.models), function (modelName) {
+        return options.models[modelName].truncate({cascade: true});
     });
   }
 


### PR DESCRIPTION
Thanks for creating this library, which I found quite usefull.
Here is a small pr that I consider an improvement:

"SET FOREIGN_KEY_CHECKS=0" is a mysqlism, which doesn't work for postgresql.
Moreover, I found it awkward that the library truncates _all_ tables as opposed to only the ones that were given to it via options.models.

This PR fixes both of these issues by applying sequelize's built in truncate() with `cascade:true` to the models passed in. Since it now operates on the models only, I took the liberty of renaming the function `truncateTables()` to `truncateModels()`.
