### PR TITLE
Don't truncate the SequelizeMeta table

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ module.exports = function (options) {
   function destroyModels() {
     return Sequelize.Promise.each(
       Object.keys(options.models), function (modelName) {
-        if (options.models[modelName] instanceof sequelize.Model) {
+        if (options.models[modelName] instanceof sequelize.Model && modelName.toLowerCase() !== 'sequelizemeta') {
           return options.models[modelName].destroy({
             where: Sequelize.literal('1=1'),
             truncate: options.truncate,


### PR DESCRIPTION
Seems that now SequelizeMeta is a proper model, which means it gets truncated. Don't do that.
