### PR TITLE
Fixed destroyModels function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,11 @@ module.exports = function (options) {
 
   // Set up test database and load fixtures
   return runMigrations().then(function () {
+    return sequelize.query("SET FOREIGN_KEY_CHECKS = 0")
+  }).then(function () {
     return destroyModels();
+  }).then(function () {
+    return sequelize.query("SET FOREIGN_KEY_CHECKS = 1")
   }).then(function () {
     return loadFixtures();
   });
@@ -54,14 +58,11 @@ module.exports = function (options) {
   function destroyModels() {
     return Sequelize.Promise.each(
       Object.keys(options.models), function (modelName) {
-        if (options.models[modelName] instanceof sequelize.Model) {
-          return options.models[modelName].destroy({
-            where: Sequelize.literal('1=1'),
-            truncate: options.truncate,
-            cascade: true,
-            force: true
-          });
-        }
+        return options.models[modelName].destroy({
+          truncate: options.truncate,
+          cascade: true,
+          force: true
+        });
       }
     );
   }


### PR DESCRIPTION
- Removed check for Sequelize.Model instance in destroyModels() function.
- Added SET FOREIGN_KEY_CHECKS in order to force truncate on database tables.